### PR TITLE
Update construqt.gemspec

### DIFF
--- a/construqt.gemspec
+++ b/construqt.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |spec|
 #  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "construqt-ipaddress", "~> 0.8.1"
+  spec.add_runtime_dependency "construqt-ipaddress", "~> 0.8.1"
   spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
fixes dependency definition in gemspec
